### PR TITLE
[RM4-36242] provide the ability to build from  a commit different from the one which triggered the workflow in ecr-build-and-push-action

### DIFF
--- a/.github/workflows/ecr-build-and-push.yml
+++ b/.github/workflows/ecr-build-and-push.yml
@@ -41,6 +41,11 @@ on:
         type: string
         default:
         required: false
+      ref:
+        description: hash of the commit to be checked out, in case you want to use a commit different from the one which triggered the workflow
+        type: string
+        default: ''
+        required: false
     secrets:
       AWS_ACCESS_KEY_ID:
         required: true
@@ -62,6 +67,8 @@ jobs:
       # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
       - name: Checkout the repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
       # Setup QEMO
       - name: Set up QEMU, required for buildx
         uses: docker/setup-qemu-action@v3


### PR DESCRIPTION
… there are commits made inside previouse steps inside the same WF